### PR TITLE
Fix misleading usage of coroutines and suspend functions

### DIFF
--- a/core/testing/src/main/java/com/android/developers/testing/data/TestFileProvider.kt
+++ b/core/testing/src/main/java/com/android/developers/testing/data/TestFileProvider.kt
@@ -26,22 +26,22 @@ import java.io.File
  * It does not perform any actual file operations.
  */
 class TestFileProvider : LocalFileProvider {
-    override fun saveBitmapToFile(
+    override suspend fun saveBitmapToFile(
         bitmap: Bitmap,
         file: File,
-    ): File {
+    ) {
         TODO("Not yet implemented")
     }
 
-    override fun getFileFromCache(fileName: String): File {
+    override suspend fun getFileFromCache(fileName: String): File {
         TODO("Not yet implemented")
     }
 
-    override fun createCacheFile(fileName: String): File {
+    override suspend fun createCacheFile(fileName: String): File {
         TODO("Not yet implemented")
     }
 
-    override fun saveToSharedStorage(
+    override suspend fun saveToSharedStorage(
         file: File,
         fileName: String,
         mimeType: String,
@@ -53,11 +53,11 @@ class TestFileProvider : LocalFileProvider {
         TODO("Not yet implemented")
     }
 
-    override fun copyToInternalStorage(uri: Uri): File {
+    override suspend fun copyToInternalStorage(uri: Uri): File {
         return File("")
     }
 
-    override fun saveUriToSharedStorage(
+    override suspend fun saveUriToSharedStorage(
         inputUri: Uri,
         fileName: String,
         mimeType: String,

--- a/data/src/main/java/com/android/developers/androidify/data/DataModule.kt
+++ b/data/src/main/java/com/android/developers/androidify/data/DataModule.kt
@@ -42,8 +42,8 @@ internal object DataModule {
 
     @Provides
     @Singleton
-    fun provideLocalFileProvider(@ApplicationContext appContext: Context): LocalFileProvider =
-        LocalFileProviderImpl(appContext)
+    fun provideLocalFileProvider(@ApplicationContext appContext: Context, @Named("IO") ioDispatcher: CoroutineDispatcher): LocalFileProvider =
+        LocalFileProviderImpl(appContext, ioDispatcher)
 
     @Provides
     @Singleton

--- a/data/src/main/java/com/android/developers/androidify/data/ImageGenerationRepository.kt
+++ b/data/src/main/java/com/android/developers/androidify/data/ImageGenerationRepository.kt
@@ -103,8 +103,8 @@ internal class ImageGenerationRepositoryImpl @Inject constructor(
 
     override suspend fun saveImage(imageBitmap: Bitmap): Uri {
         val cacheFile = localFileProvider.createCacheFile("shared_image_${UUID.randomUUID()}.jpg")
-        val file = localFileProvider.saveBitmapToFile(imageBitmap, cacheFile)
-        return localFileProvider.sharingUriForFile(file)
+        localFileProvider.saveBitmapToFile(imageBitmap, cacheFile)
+        return localFileProvider.sharingUriForFile(cacheFile)
     }
 
     override suspend fun saveImageToExternalStorage(imageBitmap: Bitmap): Uri {

--- a/feature/creation/src/main/java/com/android/developers/androidify/creation/CreationViewModel.kt
+++ b/feature/creation/src/main/java/com/android/developers/androidify/creation/CreationViewModel.kt
@@ -35,15 +35,12 @@ import com.android.developers.androidify.data.TextGenerationRepository
 import com.android.developers.androidify.util.LocalFileProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import javax.inject.Named
 
 @HiltViewModel
 class CreationViewModel @Inject constructor(
@@ -51,8 +48,6 @@ class CreationViewModel @Inject constructor(
     val imageGenerationRepository: ImageGenerationRepository,
     val textGenerationRepository: TextGenerationRepository,
     val fileProvider: LocalFileProvider,
-    @Named("IO")
-    val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     @ApplicationContext
     val context: Context,
 ) : ViewModel() {
@@ -73,6 +68,9 @@ class CreationViewModel @Inject constructor(
 
     val snackbarHostState: StateFlow<SnackbarHostState>
         get() = _snackbarHostState
+
+    private var promptGenerationJob: Job? = null
+    private var imageGenerationJob: Job? = null
 
     fun onImageSelected(uri: Uri?) {
         _uiState.update {
@@ -96,7 +94,8 @@ class CreationViewModel @Inject constructor(
     }
 
     fun onPromptGenerationClicked() {
-        viewModelScope.launch(ioDispatcher) {
+        promptGenerationJob?.cancel()
+        promptGenerationJob = viewModelScope.launch {
             Log.d("CreationViewModel", "Generating prompt...")
             _uiState.update {
                 it.copy(promptGenerationInProgress = true)
@@ -122,7 +121,8 @@ class CreationViewModel @Inject constructor(
     }
 
     fun startClicked() {
-        viewModelScope.launch(ioDispatcher) {
+        imageGenerationJob?.cancel()
+        imageGenerationJob = viewModelScope.launch {
             if (internetConnectivityManager.isInternetAvailable()) {
                 try {
                     _uiState.update {
@@ -196,7 +196,8 @@ class CreationViewModel @Inject constructor(
     }
 
     fun cancelInProgressTask() {
-        ioDispatcher.cancel()
+        promptGenerationJob?.cancel()
+        imageGenerationJob?.cancel()
         _uiState.update {
             it.copy(screenState = ScreenState.EDIT)
         }

--- a/feature/creation/src/test/kotlin/com/android/developers/androidify/creation/CreationViewModelTest.kt
+++ b/feature/creation/src/test/kotlin/com/android/developers/androidify/creation/CreationViewModelTest.kt
@@ -57,7 +57,6 @@ class CreationViewModelTest {
             imageGenerationRepository,
             TestTextGenerationRepository(),
             TestFileProvider(),
-            UnconfinedTestDispatcher(),
             context = RuntimeEnvironment.getApplication(),
         )
     }

--- a/feature/results/src/main/java/com/android/developers/androidify/results/ResultsViewModel.kt
+++ b/feature/results/src/main/java/com/android/developers/androidify/results/ResultsViewModel.kt
@@ -22,21 +22,16 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.android.developers.androidify.data.ImageGenerationRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import javax.inject.Named
 
 @HiltViewModel
 class ResultsViewModel @Inject constructor(
     val imageGenerationRepository: ImageGenerationRepository,
-    @Named("IO")
-    val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(ResultState())
@@ -58,7 +53,7 @@ class ResultsViewModel @Inject constructor(
     }
 
     fun shareClicked() {
-        viewModelScope.launch(ioDispatcher) {
+        viewModelScope.launch {
             val resultUrl = state.value.resultImageBitmap
             if (resultUrl != null) {
                 val imageFileUri = imageGenerationRepository.saveImage(resultUrl)
@@ -70,7 +65,7 @@ class ResultsViewModel @Inject constructor(
         }
     }
     fun downloadClicked() {
-        viewModelScope.launch(ioDispatcher) {
+        viewModelScope.launch {
             val resultBitmap = state.value.resultImageBitmap
             val originalImage = state.value.originalImageUrl
             if (originalImage != null) {

--- a/feature/results/src/test/kotlin/com/android/developers/androidify/results/ResultsViewModelTest.kt
+++ b/feature/results/src/test/kotlin/com/android/developers/androidify/results/ResultsViewModelTest.kt
@@ -48,7 +48,6 @@ class ResultsViewModelTest {
     fun setup() {
         viewModel = ResultsViewModel(
             FakeImageGenerationRepository(),
-            UnconfinedTestDispatcher(),
         )
     }
 


### PR DESCRIPTION
Switching to IO Dispatcher from the ViewModel classes instead of where the blocking call happens breaks the "main-safe" convention of Kotlin coroutines as well as the dispatching responsibility.

I migrated the suspending call down to where it is actually needed: in the `LocalFileProviderImpl`.

Also cleanup the unnecessary manual buffering (for copying files/streams) as Kotlin's `InputStream.copyTo()` already does it with a default 8kiB buffer.

And to keep the cancelable tasks (that was previously canceling the global IO dispatcher entirely), I've added two `Job` instances in the `CreationViewModel` that can be canceled as needed.